### PR TITLE
fix: use null as suspense fallback instead of renderFallback

### DIFF
--- a/packages/react-component-toggle/lib/components/ComponentToggle/index.tsx
+++ b/packages/react-component-toggle/lib/components/ComponentToggle/index.tsx
@@ -43,7 +43,7 @@ export const InternalComponentToggle = <
   }
 
   return (
-    <Suspense fallback={renderFallback?.() ?? null}>
+    <Suspense fallback={null}>
       <Component {...(props.componentProps as ComponentProps & React.JSX.IntrinsicAttributes)}>
         {props.children}
       </Component>


### PR DESCRIPTION
Observed behavior: the renderFallback was called when a feature was enabled, but before it was loaded.
Desired behavior: the renderFallback should only be called when a feature is disabled.

Solution: use "null" as a fallback for the Suspense instead.